### PR TITLE
Issue#10 翻訳エンドポイントの実装

### DIFF
--- a/backend/http/translate.http
+++ b/backend/http/translate.http
@@ -1,0 +1,7 @@
+POST http://127.0.0.1:5000/translate HTTP/1.1
+content-type: application/json
+
+{
+    "original_text": "こんにちは",
+    "language": "英語"
+}

--- a/backend/src/app_route.py
+++ b/backend/src/app_route.py
@@ -1,0 +1,22 @@
+import json
+
+from chat_gpt import Writer
+from flask import jsonify, request, Blueprint
+
+translate_module = Blueprint("app_route", __name__)
+
+@translate_module.route("/translate", methods=['POST'])
+def translate_text():
+    data = request.get_data().decode("utf-8", "ignore")
+    dataDict = json.loads(data)
+
+    originalStr = dataDict['original_text'] 
+    language = dataDict['language']
+
+    writer = Writer(originalStr)
+    translatedStr = writer.translatorGPT(targetLang=language)
+
+    return jsonify({
+        "language": language,
+        "translated_text": translatedStr
+    }), 200

--- a/backend/src/app_route.py
+++ b/backend/src/app_route.py
@@ -8,15 +8,15 @@ translate_module = Blueprint("app_route", __name__)
 @translate_module.route("/translate", methods=['POST'])
 def translate_text():
     data = request.get_data().decode("utf-8", "ignore")
-    dataDict = json.loads(data)
+    data_dict = json.loads(data)
 
-    originalStr = dataDict['original_text'] 
-    language = dataDict['language']
+    original_str = data_dict['original_text'] 
+    language = data_dict['language']
 
-    writer = Writer(originalStr)
-    translatedStr = writer.translatorGPT(targetLang=language)
+    writer = Writer(original_str)
+    translated_str = writer.translatorGPT(target_lang=language)
 
     return jsonify({
         "language": language,
-        "translated_text": translatedStr
+        "translated_text": translated_str
     }), 200

--- a/backend/src/chat_gpt.py
+++ b/backend/src/chat_gpt.py
@@ -8,41 +8,41 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 class Writer():
     def __init__(self, original_text:str):
         self.original_text = original_text
-        self.modelOfChatGPT = "gpt-3.5-turbo"
+        self.model_of_ChatGPT = "gpt-3.5-turbo"
 
-        self.givenMsg = {
+        self.given_msg = {
             "role": "user", "content": self.original_text
         }        
 
     def __repr__(self):
         return '\n'.join([
             f'Original text: {self.original_text}',
-            f'ChatGPT mode: {self.modelOfChatGPT}',
+            f'ChatGPT mode: {self.model_of_ChatGPT}',
         ])
     
     def __callChatGPT(self, msgs:list) -> str:
-        gptRepr = openai.ChatCompletion.create(model=self.modelOfChatGPT, messages = msgs)
+        gptRepr = openai.ChatCompletion.create(model=self.model_of_ChatGPT, messages = msgs)
         extractRepr = lambda repr: repr["choices"][0]["message"]["content"]
         return extractRepr(gptRepr)    
    
-    def translatorGPT(self, targetLang="") -> str:
-        languageOrder = F"{targetLang}に" if targetLang!="" else "日本語に"
-        translatorRoleMsg = {
+    def translatorGPT(self, target_lang="") -> str:
+        language_order = F"{target_lang}" if target_lang!="" else "日本語"
+        translator_role_msg = {
             "role": "system",
-            "content": F"あなたは与えられたテキストを{languageOrder}翻訳しなければならない。"
+            "content": F"あなたは与えられたテキストを{language_order}に翻訳しなければならない。"
         }
-        msg = [translatorRoleMsg, self.givenMsg]
-        gptAnswer = self.__callChatGPT(msg)
-        return gptAnswer
+        msg = [translator_role_msg, self.given_msg]
+        gpt_answer = self.__callChatGPT(msg)
+        return gpt_answer
 
     def summarizerGPT(self,) -> str:
-        summarizerRoleMsg = {
+        summarizer_role_msg = {
             "role": "system",
             "content": "あなたは与えられたテキストを要約しなければならない。要約結果はそのまま出力する。"
         }
-        msg = [summarizerRoleMsg, self.givenMsg]
-        gptAnswer = self.__callChatGPT(msg)
-        return gptAnswer
+        msg = [summarizer_role_msg, self.given_msg]
+        gpt_answer = self.__callChatGPT(msg)
+        return gpt_answer
     
 if __name__=="__main__":
     sampleText = """
@@ -55,11 +55,11 @@ if __name__=="__main__":
     いつの日か、だれかがこれを読んで、考えをまとめるはずだ。それが許されるのなら。
     """.replace("\n","")
     
-    rewriter = Writer(sampleText)
+    writer = Writer(sampleText)
     # 翻訳を行う時
-    result = rewriter.translatorGPT(targetLang="英語")
+    result = writer.translatorGPT(target_lang="英語")
     print(result)
 
     # 要約を行うとき
-    result = rewriter.summarizerGPT()
+    result = writer.summarizerGPT()
     print(result)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,8 +1,10 @@
-from flask import Flask
-from dotenv import load_dotenv
 import os
 
+from dotenv import load_dotenv
+from flask import Flask
 from sound2text import callWhisper
+
+from app_route import translate_module
 
 app = Flask(__name__)
 load_dotenv(verbose=True)
@@ -13,6 +15,8 @@ doDebug = True if os.getenv("DEBUG").lower() == "true" else False
 def whisper():
     messege = callWhisper("小森めと.mp4")
     return messege
+
+app.register_blueprint(translate_module)
 
 if __name__=="__main__":
     app.run(debug=doDebug, host='0.0.0.0', port=5000)


### PR DESCRIPTION
翻訳を行う、エンドポイントが使えるようになった。

### 使い方 (なんちゃってOpenAPI)

```yaml
info:
  title: Hackathon Application

servers:
  - url: http://127.0.0.1:5000

paths:
  /translate:
    post:
      summary: translate text
      requestBody:
        content:
          application/json:
            schema:
              type: object
              properties:
                original_text:
                  type: string
                  required: true
                language:
                  type: string
                  required: true
      responses:
        '200':
          description: 200 response
          content:
            application/json:
              schema:
                type: object
                properties:
                  language:
                    type: string
                  translated_text:
                    type: string

        '400':
          description: 400 response
```

### 例

```http
POST http://127.0.0.1:5000/translate HTTP/1.1
content-type: application/json

{
    "original_text": "こんにちは",
    "language": "英語"
}
```

<hr>

```http
HTTP/1.1 200 OK
Server: Werkzeug/2.3.6 Python/3.10.12
Date: Thu, 29 Jun 2023 13:21:32 GMT
Content-Type: application/json
Content-Length: 64
Connection: close

{
  "language": "\u82f1\u8a9e",
  "translated_text": "Hello."
}
```





