### PR TITLE
音声データをjson形式で返すrouteの実装

### DIFF
--- a/backend/src/route.py
+++ b/backend/src/route.py
@@ -1,7 +1,7 @@
 # 実装時点ではフロント側が未実装。そのため、動作確認を行えていない。
 # 動作確認が終了したらmain.pyに書き写す
 
-from flask import Flask
+from flask import Flask,request,jsonify
 from dotenv import load_dotenv
 import os
 import openai
@@ -19,14 +19,14 @@ def convert_audio_text():
     # POSTリクエストのボディから音声データを取得
     data = request.get_json()
     filename = data['filename']
-    file_path = f'{filename}
+    file_path = f'{filename}'
     # ファイルのパスを生成
     fpath = os.path.join(basedir, file_path)
     audio_file = open(fpath, "rb")
     # オーディオファイルをテキストに変換
     transcript = openai.Audio.transcribe("whisper-1", audio_file)
-    response = transcript.text
-    # 抽出されたテキストデータを返す
+    response = transcript
+    # 抽出されたテキストデータをjson形式で返す
     return jsonify(response)
 
 # 以下のコードは現時点では仮置き。


### PR DESCRIPTION
route.pyのconvert_audio_text()を一部書き換えた。

下記のようなPOSTメソッドで音声データが渡されるとする。
POST http://localhost:5000/convert
Content-Type: application/json

{
  "filename": "../audio/フクロウさん.m4a"
}

その結果、下記のようなjson形式でテキストデータが返される。

{
  "text": "\u3042\u3042 \u4eba\u751f\u30b2\u30fc\u30e0\u306d \u888b\u3092\u3055\u307e\u3089 \u9762\u5012\u306a\u3093\u3066\u3084\u3060\u3060\u3060 \u5168\u7136\u8db3\u308a\u306a\u3044 \u30c0\u30b9\u30c8\u30a2\u30ab\u30c7\u30df\u30fc \u4ed5\u65b9\u304c\u306a\u3044\u304b\u3089 \u77f3\u3092\u6295\u3052 \u4e07\u5e74\u3055\u3048\u306a\u3044 ・・・}