### PR TITLE
バックエンドのdev serverの実行ディレクトリを/backend/srcに統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 2. Dev Containerを起動  
 VS Codeの左下の緑色のボタンをクリックして、Reopen in Containerを選択し、VS Code on Dev Containerを起動してください。
 3. 開発サーバーを起動  
-/frontend or /backendに移動し、fronendは`yarn dev`、backendの場合は`flask run`を実行し、開発サーバーを起動してください。
+/frontend or /backend/srcに移動し、fronendは`yarn dev`、backendの場合は`flask run`を実行し、開発サーバーを起動してください。

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=base /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.
 COPY --from=base /usr/local/bin /usr/local/bin
 
 WORKDIR /app/backend
-ENV FLASK_APP=src.app
+ENV FLASK_APP=app
 
 
 # 本番環境


### PR DESCRIPTION
close #42 